### PR TITLE
update iOS unit tests workflow

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
           path: firebase-ios-sdk
       - name: Copy mock responses into SDK repo
         run: |
-          mkdir firebase-ios-sdk/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data &&
+          rm firebase-ios-sdk/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data/*
           cp -r mock-responses firebase-ios-sdk/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data
       - name: Xcode
         run: sudo xcode-select -s /Applications/${{ matrix.xcode }}.app/Contents/Developer


### PR DESCRIPTION
The directory [`vertexai-sdk-test-data`](https://github.com/firebase/firebase-ios-sdk/tree/main/FirebaseVertexAI/Tests/Unit/vertexai-sdk-test-data) was added to the SDK, so we should empty it rather than try to create it before copying mock responses over.