### PR TITLE
Add `unary-failure-firebasevertexai-api-not-enabled.json`

### DIFF
--- a/mock-responses/unary-failure-firebasevertexai-api-not-enabled.json
+++ b/mock-responses/unary-failure-firebasevertexai-api-not-enabled.json
@@ -1,0 +1,27 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Vertex AI in Firebase API has not been used in project test-project-id-1234 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/firebasevertexai.googleapis.com/overview?project=test-project-id-1234 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/firebasevertexai.googleapis.com/overview?project=test-project-id-1234"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "SERVICE_DISABLED",
+        "domain": "googleapis.com",
+        "metadata": {
+          "service": "firebasevertexai.googleapis.com",
+          "consumer": "projects/test-project-id-1234"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added an example error response when the Vertex AI in Firebase API (`firebasevertexai.googleapis.com`) is not enabled on a project.