### PR TITLE
[Infra] Fix visionOS failure in `ios-unit-tests` workflow

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -57,7 +57,7 @@ jobs:
         run: scripts/setup_spm_tests.sh
         working-directory: firebase-ios-sdk
       - name: Switch to iPhone 16 Simulator
-        run: sed -i '' 's/platform=iOS Simulator,name=iPhone 15/platform=iOS Simulator,name=iPhone 16/' scripts/build.sh
+        run: sed -i '' 's/platform=iOS Simulator,name=iPhone 15/platform=iOS Simulator,name=iPhone 16,OS=18.0/' scripts/build.sh
         working-directory: firebase-ios-sdk
       - name: Run unit tests
         run: scripts/build.sh FirebaseVertexAIUnit ${{ matrix.target }} spm

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -56,9 +56,6 @@ jobs:
       - name: Initialize xcodebuild
         run: scripts/setup_spm_tests.sh
         working-directory: firebase-ios-sdk
-      - name: Switch to iPhone 16 Simulator
-        run: sed -i '' 's/platform=iOS Simulator,name=iPhone 15/platform=iOS Simulator,name=iPhone 16,OS=18.0/' scripts/build.sh
-        working-directory: firebase-ios-sdk
       - name: Run unit tests
         run: scripts/build.sh FirebaseVertexAIUnit ${{ matrix.target }} spm
         working-directory: firebase-ios-sdk

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Initialize xcodebuild
         run: scripts/setup_spm_tests.sh
         working-directory: firebase-ios-sdk
+      - name: Switch to iPhone 16 Simulator
+        run: sed -i '' 's/platform=iOS Simulator,name=iPhone 15/platform=iOS Simulator,name=iPhone 16/' scripts/build.sh
+        working-directory: firebase-ios-sdk
       - name: Run unit tests
         run: scripts/build.sh FirebaseVertexAIUnit ${{ matrix.target }} spm
         working-directory: firebase-ios-sdk

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -32,10 +32,9 @@ jobs:
     strategy:
       matrix:
         target: [iOS, macOS, catalyst, tvOS, visionOS]
-        os: [macos-14]
         include:
-          - os: macos-14
-            xcode: Xcode_15.2
+          - os: macos-15
+            xcode: Xcode_16
     runs-on: ${{ matrix.os }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1


### PR DESCRIPTION
Switched to the macOS 15 GitHub runner image to regain access to the [visionOS simulator](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-simulators).