### PR TITLE
Add error payload for `IAM_PERMISSION_DENIED`

### DIFF
--- a/mock-responses/unary-failure-iam-permission-denied.json
+++ b/mock-responses/unary-failure-iam-permission-denied.json
@@ -1,0 +1,18 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Permission 'aiplatform.endpoints.predict' denied on resource '//aiplatform.googleapis.com/projects/test-project-id-1234/locations/us-central1/publishers/google/models/gemini-1.5-flash' (or it may not exist).",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "IAM_PERMISSION_DENIED",
+        "domain": "aiplatform.googleapis.com",
+        "metadata": {
+          "permission": "aiplatform.endpoints.predict",
+          "resource": "projects/test-project-id-1234/locations/us-central1/publishers/google/models/gemini-1.5-flash"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This error occurs when the [Firebase Service Account](https://firebase.google.com/support/guides/service-accounts) on the project isn't correctly configured for Vertex AI in Firebase. This typically occurs briefly after activating the API (in response to [`SERVICE_DISABLED`](https://github.com/FirebaseExtended/vertexai-sdk-test-data/blob/60d747efe8d8028512fc2172a0f664b6c7858730/mock-responses/unary-failure-firebasevertexai-api-not-enabled.json)) and resolves by re-running the request. However, it could also occur if the Firebase Service Account has been edited manually in the GCP Console.