### PR TITLE
[Coverage Tool] Update `DISCOVERY_DOC_URL` to `firebasevertexai`

### DIFF
--- a/coverage-tool/coverage_tool.py
+++ b/coverage-tool/coverage_tool.py
@@ -26,7 +26,7 @@ from glob import glob
 from sys import stderr
 from urllib.request import urlopen
 
-DISCOVERY_DOC_URL = "https://aiplatform.googleapis.com/$discovery/rest?version=v1beta1"
+DISCOVERY_DOC_URL = "https://firebasevertexai.googleapis.com/$discovery/rest?version=v1beta1"
 SCHEMA_PREFIX = "GoogleCloudAiplatformV1beta1"
 RESPONSE_TYPES = ["GenerateContentResponse", "CountTokensResponse"]
 SCRIPT_DIR = os.path.dirname(__file__)

--- a/coverage-tool/coverage_tool.py
+++ b/coverage-tool/coverage_tool.py
@@ -26,7 +26,7 @@ from glob import glob
 from sys import stderr
 from urllib.request import urlopen
 
-DISCOVERY_DOC_URL = "https://firebasevertexai.googleapis.com/$discovery/rest?version=v1beta1"
+DISCOVERY_DOC_URL = "https://firebasevertexai.googleapis.com/$discovery/rest?version=v1beta"
 SCHEMA_PREFIX = "GoogleCloudAiplatformV1beta1"
 RESPONSE_TYPES = ["GenerateContentResponse", "CountTokensResponse"]
 SCRIPT_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
Updated the `DISCOVERY_DOC_URL` from `https://aiplatform.googleapis.com/$discovery/rest?version=v1beta1` to `https://firebasevertexai.googleapis.com/$discovery/rest?version=v1beta` since the SDKs only care about services, fields, etc., offered by the Vertex AI in Firebase proxy.

Note: Coverage is currently identical since `coverage_tool.py` filters by `RESPONSE_TYPES = ["GenerateContentResponse", "CountTokensResponse"]`.