### PR TITLE
Add mock responses with empty text parts

### DIFF
--- a/mock-responses/streaming-success-empty-text-part.txt
+++ b/mock-responses/streaming-success-empty-text-part.txt
@@ -1,3 +1,3 @@
 data: {"candidates":[{"content":{"role":"model","parts":[{"text":"1"}]}}]}
 
-data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP",}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1,"totalTokenCount":9}}
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1,"totalTokenCount":9}}

--- a/mock-responses/streaming-success-empty-text-part.txt
+++ b/mock-responses/streaming-success-empty-text-part.txt
@@ -1,0 +1,3 @@
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":"1"}]}}]}
+
+data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP",}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1,"totalTokenCount":9}}

--- a/mock-responses/unary-success-empty-text-part.json
+++ b/mock-responses/unary-success-empty-text-part.json
@@ -1,0 +1,20 @@
+{
+  "candidates": [
+    {
+      "content": {
+        "role": "model",
+        "parts": [
+          {
+            "text": ""
+          }
+        ]
+      },
+      "finishReason": "STOP"
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 8,
+    "totalTokenCount": 8
+  },
+  "modelVersion": "gemini-2.0-flash-exp"
+}


### PR DESCRIPTION
The backend can return responses with empty text parts. We should know how our SDKs handle these.

If these empty text parts are send back to the model in a chat history, the backend will respond with an error.