### PR TITLE
Add newline to `streaming-success-empty-text-part.txt`

### DIFF
--- a/mock-responses/streaming-success-empty-text-part.txt
+++ b/mock-responses/streaming-success-empty-text-part.txt
@@ -1,3 +1,4 @@
 data: {"candidates":[{"content":{"role":"model","parts":[{"text":"1"}]}}]}
 
 data: {"candidates":[{"content":{"role":"model","parts":[{"text":""}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":1,"totalTokenCount":9}}
+


### PR DESCRIPTION
The JS SDK uses `\n\n` in a regular expression to find the end of the data. I forgot to add this in #27.

https://github.com/firebase/firebase-js-sdk/blob/main/packages/vertexai/src/requests/stream-reader.ts#L29