### PR TITLE
Add newline to end of `streaming-success-basic-reply-long.txt`

### DIFF
--- a/mock-responses/vertexai/streaming-success-basic-reply-long.txt
+++ b/mock-responses/vertexai/streaming-success-basic-reply-long.txt
@@ -5,3 +5,4 @@ data: {"candidates": [{"content": {"role": "model","parts": [{"text": ", let'"}]
 data: {"candidates": [{"content": {"role": "model","parts": [{"text": "s brew a decent cup of coffee! Here's a breakdown of how to"}]}}],"usageMetadata": {"trafficType": "ON_DEMAND"},"modelVersion": "gemini-2.0-flash","createTime": "2025-05-05T21:30:47.262229Z","responseId": "By4ZaNWAEPKQhMIP4KS3oAc"}
 
 data: {"candidates": [{"content": {"role": "model","parts": [{"text": " a little practice, you'll be brewing delicious coffee in no time.\n"}]},"finishReason": "STOP"}],"usageMetadata": {"promptTokenCount": 12,"candidatesTokenCount": 1706,"totalTokenCount": 1718,"trafficType": "ON_DEMAND","promptTokensDetails": [{"modality": "TEXT","tokenCount": 12}],"candidatesTokensDetails": [{"modality": "TEXT","tokenCount": 1706}]},"modelVersion": "gemini-2.0-flash","createTime": "2025-05-05T21:30:47.262229Z","responseId": "By4ZaNWAEPKQhMIP4KS3oAc"}
+


### PR DESCRIPTION
The JS SDK expects data chunks to end with `\n\n|\r\r|\r\n\r\n`, but the last chunk in this file ends with `\r\n`. Adding `\r\n` to our regular expression breaks other tests, so just adding a newline to this file is easier...

This fixes the two JS tests that broke in CI.