### PR TITLE
Add test data for generative language api disabled

### DIFF
--- a/mock-responses/googleai/unary-failure-generativelanguage-api-not-enabled.json
+++ b/mock-responses/googleai/unary-failure-generativelanguage-api-not-enabled.json
@@ -1,0 +1,27 @@
+{
+  "error": {
+    "code": 403,
+    "message": "Generative Language API has not been used in project 12345678 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=12345678 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
+    "status": "PERMISSION_DENIED",
+    "details": [
+      {
+        "@type": "type.googleapis.com/google.rpc.Help",
+        "links": [
+          {
+            "description": "Google developers console API activation",
+            "url": "https://console.developers.google.com/apis/api/generativelanguage.googleapis.com/overview?project=12345678"
+          }
+        ]
+      },
+      {
+        "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+        "reason": "SERVICE_DISABLED",
+        "domain": "googleapis.com",
+        "metadata": {
+          "service": "generativelanguage.googleapis.com",
+          "consumer": "projects/12345678"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add googleai mock response for the case when Gemini Developer API is disabled