### PR TITLE
[CI] Run `ios-unit-tests` using Xcode 16.4

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
         target: [iOS, macOS, catalyst, tvOS, visionOS]
         include:
           - os: macos-15
-            xcode: Xcode_16
+            xcode: Xcode_16.4
     runs-on: ${{ matrix.os }}
     env:
       FIREBASECI_USE_LATEST_GOOGLEAPPMEASUREMENT: 1


### PR DESCRIPTION
These tests were running on Xcode 16.0, which no longer includes the simulator runtimes by default in GitHub Actions runner images.

> Platform tools (SDK and simulator runtimes) will only be available for the three most recently installed versions of Xcode, including beta and pre-release versions for macOS-15-based and later images.
-- https://github.com/actions/runner-images/issues/12541

